### PR TITLE
Adding c++ version of nstream test with GPU support

### DIFF
--- a/crates/wasi-parallel/Cargo.toml
+++ b/crates/wasi-parallel/Cargo.toml
@@ -54,3 +54,8 @@ harness = false
 [[bench]]
 name = "arithmetic"
 harness = false
+
+[[bench]]
+name = "nstream_cpp"
+harness = false
+

--- a/crates/wasi-parallel/benches/arithmetic/parallel.wat
+++ b/crates/wasi-parallel/benches/arithmetic/parallel.wat
@@ -52,7 +52,7 @@ checking provided! ;)
     )
 
     (; Register the kernel as reference-able. ;)
-    (table (export "table") 1 funcref)
+    (table (export "__indirect_function_table") 1 funcref)
     (elem (i32.const 0) $add)
 
     (memory (export "memory") 1)

--- a/crates/wasi-parallel/benches/cl/nstream_cpp.cl
+++ b/crates/wasi-parallel/benches/cl/nstream_cpp.cl
@@ -1,0 +1,12 @@
+
+typedef float BufferArrayType;
+
+__kernel void spir_main(__global BufferArrayType *context,
+                        __global BufferArrayType *bufA,
+                        __global BufferArrayType *bufB,
+                        __global BufferArrayType *bufC) {
+  int idx = get_global_id(0);
+  const BufferArrayType scalar = context[1];
+
+  bufA[idx] = bufA[idx] + bufB[idx] * scalar + bufC[idx];
+}

--- a/crates/wasi-parallel/benches/cpp/nstream_cpp.cpp
+++ b/crates/wasi-parallel/benches/cpp/nstream_cpp.cpp
@@ -1,0 +1,85 @@
+
+#include "../../tests/cpp/wasi_parallel.h"
+
+#include <algorithm>
+#include <cstdio>
+
+void cpu_worker(int thread_id, int num_threads, int block_size,
+                float *ctx, int ctx_len,
+                float *A, int A_len,
+                float *B, int B_len,
+                float *C, int C_len)
+{
+
+    const int offset = thread_id * block_size;
+    for (int b = offset; b < (offset + block_size); ++b)
+    {
+        A[b] += B[b] + ctx[1] * C[b];
+    }
+}
+
+int main(int argc, char **argv)
+{
+    return 0;
+}
+
+const int buffer_size = 0x2000000;
+int device;
+int aBufH;
+float aBuf[0x2000000];
+int bBufH;
+float bBuf[0x2000000];
+int cBufH;
+float cBuf[0x2000000];
+int ctxBufH;
+// opencl seems to have a problem with 0th element
+float ctxBuf[2];
+bool force_sequential;
+int exec_mode;
+
+// modes:
+//  0. sequential
+//  1. CPU
+//  2. GPU
+__attribute__((export_name("setup"))) void setup(int mode)
+{
+    force_sequential = mode == 0;
+    exec_mode = mode;
+
+    get_device(mode == 1 ? CPU: DISCRETE_GPU, &device);
+
+    create_buffer(device, sizeof(aBuf), ReadWrite, &aBufH);
+    create_buffer(device, sizeof(bBuf), Read, &bBufH);
+    create_buffer(device, sizeof(cBuf), Read, &cBufH);
+    create_buffer(device, sizeof(int) * 2, Read, &ctxBufH);
+    std::fill_n(aBuf, buffer_size, 0);
+    std::fill_n(bBuf, buffer_size, 2);
+    std::fill_n(cBuf, buffer_size, 2);
+    ctxBuf[0] = 0;
+    ctxBuf[1] = 3;
+    write_buffer(aBuf, sizeof(aBuf), aBufH);
+    write_buffer(bBuf, sizeof(bBuf), bBufH);
+    write_buffer(cBuf, sizeof(cBuf), cBufH);
+    write_buffer(ctxBuf, sizeof(ctxBuf), ctxBufH);
+}
+
+__attribute__((export_name("run"))) void run()
+{
+    if (!force_sequential)
+    {
+        int in_buf[] = {ctxBufH, aBufH, bBufH, cBufH};
+        const int num_threads = exec_mode == 1 ? 8 : 32;
+        parallel_for(reinterpret_cast<void *>(cpu_worker),
+            num_threads, buffer_size / num_threads,
+            in_buf, sizeof(in_buf) / sizeof(int),
+            0, 0);
+    }
+    else
+    {
+        cpu_worker(0, 1, buffer_size,
+                   ctxBuf, 2,
+                   aBuf, buffer_size,
+                   bBuf, buffer_size,
+                   cBuf, buffer_size);
+    }
+}

--- a/crates/wasi-parallel/benches/nstream/parallel.wat
+++ b/crates/wasi-parallel/benches/nstream/parallel.wat
@@ -72,7 +72,7 @@ for a higher-level implementation. ;)
     )
 
     (; Register the nstream kernel as reference-able ;)
-    (table (export "table") 1 funcref)
+    (table (export "__indirect_function_table") 1 funcref)
     (elem (i32.const 0) $nstream)
 
     (memory (export "memory") 0x800)

--- a/crates/wasi-parallel/benches/nstream_cpp.rs
+++ b/crates/wasi-parallel/benches/nstream_cpp.rs
@@ -1,0 +1,42 @@
+mod run;
+use criterion::{
+    criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
+};
+use run::BenchContext;
+use std::path::Path;
+use wasmtime::Val;
+
+#[derive(Debug, Clone, Copy)]
+enum ExecMode {
+    Sequential = 0,
+    CPU = 1,
+    GPU = 2,
+}
+
+fn bench_nstream(c: &mut Criterion) {
+    let mut group = c.benchmark_group("nstream_cpp");
+    measure_wasm(
+        &mut group,
+        "benches/wasm/nstream_cpp.wasm",
+        ExecMode::Sequential,
+    );
+    measure_wasm(&mut group, "benches/wasm/nstream_cpp.wasm", ExecMode::CPU);
+    measure_wasm(&mut group, "benches/wasm/nstream_cpp.wasm", ExecMode::GPU);
+}
+
+fn measure_wasm<P: AsRef<Path>>(group: &mut BenchmarkGroup<WallTime>, path: P, mode: ExecMode) {
+    let path = path.as_ref();
+    let mut ctx = BenchContext::new(path).unwrap();
+    ctx.invoke("setup", Some(vec![Val::I32(mode as i32)]))
+        .unwrap();
+
+    group.bench_function(
+        format!("{} (seq: {:?})", path.to_string_lossy(), mode),
+        |b| {
+            b.iter(|| ctx.invoke("run", None));
+        },
+    );
+}
+
+criterion_group!(benches, bench_nstream);
+criterion_main!(benches);

--- a/crates/wasi-parallel/benches/run.rs
+++ b/crates/wasi-parallel/benches/run.rs
@@ -1,13 +1,18 @@
-use anyhow::{Context, Result};
-use std::path::Path;
+use anyhow::{anyhow, Context as _, Result};
+use std::path::{Path, PathBuf};
 use structopt::StructOpt;
+use wasmtime::{AsContextMut, Config, Engine, Instance, Linker, Module, Store, Val};
 use wasmtime_cli::commands::RunCommand;
+use wasmtime_wasi::WasiCtxBuilder;
+use wasmtime_wasi_parallel::WasiParallel;
 
 /// Run a Wasm module as if from the Wasmtime CLI application. This is quite
 /// helpful for testing and benchmarking but it is expected that users will
 /// actually run the following from a shell: `wasmtime run --wasi-modules
 /// experimental-wasi-parallel <MODULE>`.
 #[cfg(test)]
+// TODO: Fix silly warnings
+#[allow(dead_code)]
 pub fn run<P: AsRef<Path>>(path: P) -> Result<()> {
     let path = path
         .as_ref()
@@ -16,4 +21,96 @@ pub fn run<P: AsRef<Path>>(path: P) -> Result<()> {
     let command =
         RunCommand::from_iter_safe(&["run", "--wasi-modules", "experimental-wasi-parallel", path])?;
     command.execute()
+}
+
+#[derive(Default)]
+struct Host {
+    wasi: Option<wasmtime_wasi::WasiCtx>,
+    wasi_parallel: Option<WasiParallel>,
+}
+
+pub struct BenchContext {
+    store: Store<Host>,
+    instance: Instance,
+}
+
+impl BenchContext {
+    // TODO: Fix silly warnings
+    #[allow(dead_code)]
+    /// Create a BenchContext, this allows use to better split setup and run timings.
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<BenchContext> {
+        let path = PathBuf::from(
+            path.as_ref()
+                .to_str()
+                .context("unable to convert path to string")?,
+        );
+        let config: Config = Config::new();
+        let engine = Engine::new(&config)?;
+        let mut store = Store::new(&engine, Host::default());
+        let mut linker = Linker::new(&engine);
+
+        populate_with_wasi(&mut store, &mut linker, &path)?;
+
+        let module = Module::from_file(linker.engine(), &path)?;
+        let instance = linker.instantiate(&mut store, &module)?;
+        invoke_default(&mut store, &instance)?;
+
+        Ok(BenchContext { store, instance })
+    }
+
+    // TODO: Fix silly warnings
+    #[allow(dead_code)]
+    pub fn invoke(&mut self, name: &str, args: Option<Vec<Val>>) -> Result<Box<[Val]>> {
+        let func = self
+            .instance
+            .get_func(&mut self.store, name)
+            .ok_or_else(|| anyhow!("no export named `{}` found", name))?;
+
+        func.call(&mut self.store, &args.unwrap_or(vec![]))
+    }
+}
+
+// TODO: Fix silly warnings
+#[allow(dead_code)]
+fn invoke_default(store: &mut Store<Host>, instance: &Instance) -> Result<()> {
+    if let Some(func) = instance.get_func(store.as_context_mut(), "") {
+        func.call(store.as_context_mut(), &[])?;
+        return Ok(());
+    }
+
+    if let Some(func) = instance.get_func(store.as_context_mut(), "_start") {
+        func.call(store.as_context_mut(), &[])?;
+        return Ok(());
+    }
+
+    Ok(())
+}
+
+// TODO: Fix silly warnings
+#[allow(dead_code)]
+fn populate_with_wasi(
+    store: &mut Store<Host>,
+    linker: &mut Linker<Host>,
+    module_path: &PathBuf,
+) -> Result<()> {
+    // Add wasi-common
+    wasmtime_wasi::add_to_linker(linker, |host| host.wasi.as_mut().unwrap())?;
+
+    let builder = WasiCtxBuilder::new().inherit_stdio();
+
+    store.data_mut().wasi = Some(builder.build());
+
+    // Add wasi-parallel
+    wasmtime_wasi_parallel::add_to_linker(linker, |host| host.wasi_parallel.as_mut().unwrap())?;
+    let module_bytes = std::fs::read(module_path)?;
+    let spirv_sections =
+        if let Ok(sections) = wasmtime_wasi_parallel::find_custom_spirv_sections(&module_bytes) {
+            sections
+        } else {
+            log::warn!("unable to find wasi-parallel custom sections");
+            Vec::new()
+        };
+    store.data_mut().wasi_parallel = Some(WasiParallel::new(spirv_sections));
+
+    Ok(())
 }


### PR DESCRIPTION
I created a c++ version of the nstream test because it was impossible to pick the correct indirect function index in the rust version. The rust runtime seems need a lot more indirect calls than wasi-libc.

I also created a different version of the benchmark harness that enables us able to split the setup code out of the timing loop. Unfortunately, it seems to cause a ton of "dead_code" warnings that I'm not 100% sure how to fix.